### PR TITLE
Set Mac (and maybe iPhone) to unix

### DIFF
--- a/emp-tool/utils/constants.h
+++ b/emp-tool/utils/constants.h
@@ -12,7 +12,7 @@ const static int PUBLIC = 0;
 const static int ALICE = 1;
 const static int BOB = 2;
 
-#if defined(unix) || defined(__unix__) || defined(__unix)
+#if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
 #define UNIX_PLATFORM
 #endif
 }


### PR DESCRIPTION
It seems socket provides the best speed and should also let Mac use socket.