### PR TITLE
Add AES compile-time check

### DIFF
--- a/emp-tool/garble/aes.h
+++ b/emp-tool/garble/aes.h
@@ -53,7 +53,7 @@
 #define LIBGARBLE_AES_H
 
 #if !defined (__AES__)
-    # error "AES-NI instructions not enabled"
+    #error "AES-NI instructions not enabled"
 #endif
 
 #include "emp-tool/utils/block.h"

--- a/emp-tool/garble/aes.h
+++ b/emp-tool/garble/aes.h
@@ -52,6 +52,10 @@
 #ifndef LIBGARBLE_AES_H
 #define LIBGARBLE_AES_H
 
+#if !defined (__AES__)
+    # error "AES-NI instructions not enabled"
+#endif
+
 #include "emp-tool/utils/block.h"
 
 namespace emp { 


### PR DESCRIPTION
It should be sufficient to put it in `emp-tool`since others are calling the binary of this one.

This one runs well also in (my) Mac.