### PR TITLE
Use FindGMP instead of hardcoded paths for gmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 2.8.11)
 project (emptool)
 set(NAME "emp-tool")
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW) # use rpath on macOS
@@ -18,8 +19,9 @@ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
 find_package(OpenSSL REQUIRED)
 find_package(relic REQUIRED)
+find_package(GMP REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system)
-include_directories(${RELIC_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+include_directories(${RELIC_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${GMP_INCLUDE_DIR})
 
 set (CMAKE_C_FLAGS "-pthread -Wall -march=native -O3 -maes -mrdseed")
 set (CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
@@ -49,7 +51,7 @@ install(TARGETS ${NAME} DESTINATION lib)
 
 macro (add_test _name)
 	add_executable(${_name} "test/${_name}.cpp" ${sources})
-	target_link_libraries(${_name}  ${RELIC_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} gmp) 
+	target_link_libraries(${_name}  ${RELIC_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} ${GMP_LIBRARIES}) 
 endmacro()
 
 add_test(prg)

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,0 +1,21 @@
+# https://raw.githubusercontent.com/stevedekorte/io/master/modules/FindGMP.cmake
+
+# Try to find the GMP librairies
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+		# Already in cache, be silent
+		set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h )
+find_library(GMP_LIBRARIES NAMES gmp libgmp )
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
+MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)

--- a/cmake/emp-tool-config.cmake
+++ b/cmake/emp-tool-config.cmake
@@ -1,5 +1,28 @@
-find_package(OpenSSL)
-find_package(relic)
+find_package(OpenSSL REQUIRED)
+find_package(relic REQUIRED)
+find_package(Boost REQUIRED COMPONENTS system)
+
+# GMP
+# https://raw.githubusercontent.com/stevedekorte/io/master/modules/FindGMP.cmake
+
+# Try to find the GMP librairies
+# GMP_FOUND - system has GMP lib
+# GMP_INCLUDE_DIR - the GMP include directory
+# GMP_LIBRARIES - Libraries needed to use GMP
+
+if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+		# Already in cache, be silent
+		set(GMP_FIND_QUIETLY TRUE)
+endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h )
+find_library(GMP_LIBRARIES NAMES gmp libgmp )
+find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
+MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
+
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)
+# end of GMP
+
 find_path(EMP-TOOL_INCLUDE_DIR NAMES emp-tool/emp-tool.h)
 find_library(EMP-TOOL_LIBRARY NAMES emp-tool)
 
@@ -8,6 +31,6 @@ find_package_handle_standard_args(EMP-TOOL DEFAULT_MSG EMP-TOOL_INCLUDE_DIR EMP-
 
 add_definitions(-DEMP_CIRCUIT_PATH=${EMP-TOOL_INCLUDE_DIR}/emp-tool/circuits/files/)
 if(EMP-TOOL_FOUND)
-	set(EMP-TOOL_LIBRARIES ${EMP-TOOL_LIBRARY} ${RELIC_LIBRARIES} ${OPENSSL_LIBRARIES} gmp boost_system)
-	set(EMP-TOOL_INCLUDE_DIRS ${EMP-TOOL_INCLUDE_DIR} ${RELIC_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
+	set(EMP-TOOL_LIBRARIES ${EMP-TOOL_LIBRARY} ${RELIC_LIBRARIES} ${OPENSSL_LIBRARIES} ${Boost_LIBRARIES} ${GMP_LIBRARIES})
+	set(EMP-TOOL_INCLUDE_DIRS ${EMP-TOOL_INCLUDE_DIR} ${RELIC_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${GMP_INCLUDE_DIR})
 endif()


### PR DESCRIPTION
So that GMP can be found even if it is not in a standard location.
(Same for Boost.)