### PR TITLE
Adding back the policy CMP0042 for rpath on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required (VERSION 2.8.11)
 project (emptool)
 set(NAME "emp-tool")
 
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW) # use rpath on macOS
+endif()
+
 include(cmake/common.cmake)
 include(cmake/source_of_randomness.cmake)
 include(cmake/threading.cmake)


### PR DESCRIPTION
Without this policy, rpath is disabled on macOS, which generates many issues when the library is not installed in a standard path, because of System Integrity Protection which prevents `DYLD_LIBRARY_PATH` from being inherited in shells.

In particular, using `lldb` would not work on a library located in a non-standard path without rpath (see, e.g., https://stackoverflow.com/a/33589760)