### PR TITLE
Make `initialized` a function-scope static variable

### DIFF
--- a/emp-tool/utils/utils_ec.h
+++ b/emp-tool/utils/utils_ec.h
@@ -52,7 +52,6 @@ __batch3(bn_add);
 
 void bn_to_block(block * b, const bn_t bn);
 void block_to_bn(bn_t bn, const block * b);
-static bool initialized = false;
 void initialize_relic();
 
 block KDF(eb_t in);

--- a/emp-tool/utils/utils_ec.hpp
+++ b/emp-tool/utils/utils_ec.hpp
@@ -6,13 +6,13 @@ inline void block_to_bn(bn_t bn, const block * b) {
 	bn_read_bin(bn, (const uint8_t*)b, sizeof(block));
 }
 inline void initialize_relic() {
+	static bool initialized = false;
 	if(initialized) return;
 	initialized = true;
 	if (core_init() != STS_OK) {
 		core_clean();
 		exit(1);
 	}
-
 	eb_param_set(EBACS_B251);
 }
 


### PR DESCRIPTION
This is [thread safe as of C++11](https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables), whereas the previous version isn't.