### PR TITLE
Close listening socket after accepting a connection

### DIFF
--- a/emp-tool/io/net_io_channel.h
+++ b/emp-tool/io/net_io_channel.h
@@ -56,6 +56,7 @@ class NetIO: public IOChannel<NetIO> { public:
 				exit(1);
 			}
 			consocket = accept(mysocket, (struct sockaddr *)&dest, &socksize);
+			close(mysocket);
 		}
 		else {
 			addr = string(address);


### PR DESCRIPTION
This enables multiple NetIOs on the same port in the same process.