### PR TITLE
Guard functions with non-standard instructions by target attributes

### DIFF
--- a/emp-tool/garble/aes.h
+++ b/emp-tool/garble/aes.h
@@ -7,7 +7,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -52,13 +52,9 @@
 #ifndef LIBGARBLE_AES_H
 #define LIBGARBLE_AES_H
 
-#if !defined (__AES__)
-    #error "AES-NI instructions not enabled"
-#endif
-
 #include "emp-tool/utils/block.h"
 
-namespace emp { 
+namespace emp {
 
 typedef struct { block rd_key[11]; unsigned int rounds; } AES_KEY;
 
@@ -73,7 +69,8 @@ typedef struct { block rd_key[11]; unsigned int rounds; } AES_KEY;
     v2 = _mm_shuffle_epi32(v2,shuff_const);                                 \
     v1 = _mm_xor_si128(v1,v2)
 
-static inline void
+inline void
+__attribute__((target("aes,sse2")))
 AES_set_encrypt_key(const block userkey, AES_KEY *key)
 {
     block x0, x1, x2;
@@ -103,7 +100,8 @@ AES_set_encrypt_key(const block userkey, AES_KEY *key)
     key->rounds = 10;
 }
 
-static inline void
+inline void
+__attribute__((target("aes,sse2")))
 AES_ecb_encrypt_blks(block *blks, unsigned int nblks, const AES_KEY *key)
 {
     for (unsigned int i = 0; i < nblks; ++i)
@@ -115,7 +113,8 @@ AES_ecb_encrypt_blks(block *blks, unsigned int nblks, const AES_KEY *key)
         blks[i] = _mm_aesenclast_si128(blks[i], key->rd_key[key->rounds]);
 }
 
-static inline void
+inline void
+__attribute__((target("aes,sse2")))
 AES_set_decrypt_key_fast(AES_KEY *dkey, const AES_KEY *ekey)
 {
     int j = 0;
@@ -129,7 +128,8 @@ AES_set_decrypt_key_fast(AES_KEY *dkey, const AES_KEY *ekey)
     dkey->rd_key[i] = ekey->rd_key[j];
 }
 
-static inline void
+inline void
+__attribute__((target("aes,sse2")))
 AES_set_decrypt_key(block userkey, AES_KEY *key)
 {
     AES_KEY temp_key;
@@ -137,7 +137,8 @@ AES_set_decrypt_key(block userkey, AES_KEY *key)
     AES_set_decrypt_key_fast(key, &temp_key);
 }
 
-static inline void
+inline void
+__attribute__((target("aes,sse2")))
 AES_ecb_decrypt_blks(block *blks, unsigned nblks, const AES_KEY *key)
 {
     unsigned i, j, rnds = key->rounds;

--- a/emp-tool/utils/block.h
+++ b/emp-tool/utils/block.h
@@ -228,7 +228,7 @@ inline block RIGHTSHIFT(block bl) {
 
 	  Contact GitHub API Training Shop Blog About
 	 */
-__attribute__((target("sse2,vpclmulqdq")))
+__attribute__((target("sse2,pclmul")))
 inline void mul128(__m128i a, __m128i b, __m128i *res1, __m128i *res2) {
 	/*	block a0xora1 = xorBlocks(a, _mm_srli_si128(a, 8));
 		block b0xorb1 = xorBlocks(b, _mm_srli_si128(b, 8));

--- a/emp-tool/utils/hash.h
+++ b/emp-tool/utils/hash.h
@@ -53,6 +53,7 @@ class Hash { public:
 	static void hash_once(void * digest, const void * data, int nbyte) {
 		(void )SHA256((const unsigned char *)data, nbyte, (unsigned char *)digest);
 	}
+	__attribute__((target("sse2")))
 	static block hash_for_block(const void * data, int nbyte) {
 		char digest[DIGEST_SIZE];
 		hash_once(digest, data, nbyte);

--- a/emp-tool/utils/xor_tree.h
+++ b/emp-tool/utils/xor_tree.h
@@ -26,7 +26,7 @@ class XorTree{public:
 	}
 	void circuitN(block* out, block * in, int dim = N) {
 		assert(dim <= N);
-	
+
 		for(int i = 0; i < dim; ++i) {
 			block res = zero_block();
 			for(int j = 0; j < M; ++j) {
@@ -52,7 +52,7 @@ class XorTree{public:
 		prg->random_data(tmp, M);
 		for(int i = 0; i < M; ++i)
 			out[i] = (tmp[i]%2==1);
-	
+
 		for(int i = 0; i < dim; ++i) {
 			bool res = false;
 			for(int j = 0; j < M; ++j) {


### PR DESCRIPTION
This adds [`__attribute__((target("...")))`](https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-target-function-attribute) to functions that use instructions from specific instruction sets such as `aes`, `sse2`, `pclmul`, and so on.

The goal is to allow libraries to transitively depend on EMP, without having to pass `-maes -msse4 -mpclmul` in every compilation unit. For example, if `example.cpp` (transitively) includes `emp-tool.h`, but doesn't use any EMP functions or instantiate its templates, then `gcc example.cpp` should compile just fine.

For this to work, I had to remove the compile-time check for `__AES__` (see #37). I'm not sure that was needed, though. All it did was force users to pass `-maes` at compilation, but the resulting binaries would not run on machines that didn't have AES-NI. Now, `-maes` doesn't need to be passed, and the resulting binaries still run the same machines they did before. To add some safety (and useful error messages), it might makes sense to have a runtime check for the necessary instruction sets, but I think this can be done in a different PR.