### PR TITLE
Update common.cmake to remove dup text

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -1,10 +1,3 @@
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	if(NOT DEFINED OPENSSL_ROOT_DIR)
-		set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl")	
-		message(STATUS "OPENSSL_ROOT_DIR set to default: ${OPENSSL_ROOT_DIR}")
-	endif()
-endif()
-
 if(NOT WIN32)
   string(ASCII 27 Esc)
   set(ColourReset "${Esc}[m")


### PR DESCRIPTION
OPENSSL_ROOT_DIR was set twice on Macs. I don't have one, but having stared at the file for a while, it indeed looks like a typo. I left the second copy of the conditional because that's around the same place as where CMAKE_MACOSX_RPATH is zeroed.