### PR TITLE
Update FindGMP.cmake to remove redundant prefix

### DIFF
--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -11,8 +11,8 @@ if (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
 endif (GMP_INCLUDE_DIR AND GMP_LIBRARIES)
 
 find_path(GMP_INCLUDE_DIR NAMES gmp.h )
-find_library(GMP_LIBRARIES NAMES gmp libgmp )
-find_library(GMPXX_LIBRARIES NAMES gmpxx libgmpxx )
+find_library(GMP_LIBRARIES NAMES gmp )
+find_library(GMPXX_LIBRARIES NAMES gmpxx )
 MESSAGE(STATUS "GMP libs: " ${GMP_LIBRARIES} " " ${GMPXX_LIBRARIES} )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
CMake will try "lib" and other prefixes (and suffixes) already, per [documentation](https://cmake.org/cmake/help/latest/command/find_library.html):

> Each library name given to the NAMES option is first considered as a library file name and then considered with platform-specific prefixes (e.g. lib) and suffixes (e.g. .so). Therefore one may specify library file names such as libfoo.a directly. This can be used to locate static libraries on UNIX-like systems.
