### PR TITLE
Update common.cmake to use compile options

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -33,8 +33,8 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 #Compilation flags
-set(CMAKE_C_FLAGS "-pthread -Wall -march=native -O3 -maes -mrdseed")
-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
+add_compile_options(-pthread -Wall -march=native -O3 -maes -mrdseed)
+set(CMAKE_CXX_FLAGS "-std=c++11")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -ggdb")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
Tested briefly, in that the flags in an arbitrarily-chosen subdirectory of CMakeFiles were still right.
I also wanted to use the CMAKE_CXX_STANDARD variable, but that would bump the minimum CMake version to 3.1 or so. Apparently FindThread, when the right target is linked, will get the flags right there too: https://stackoverflow.com/questions/5395309/how-do-i-force-cmake-to-include-pthread-option-during-compilation, but that seemed like a hassle.