### PR TITLE
Set optimization level by build type

### DIFF
--- a/cmake/common.cmake
+++ b/cmake/common.cmake
@@ -33,10 +33,10 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 #Compilation flags
-set(CMAKE_C_FLAGS "-pthread -Wall -march=native -O3 -maes -mrdseed")
+set(CMAKE_C_FLAGS "-pthread -Wall -march=native -maes -mrdseed")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++11")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -ggdb")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} -ggdb -O0")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} -O3")
 
 ## Build type
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
`-Og` would be another option for debugging, but I figure `-O0` is safest.