### PR TITLE
Delete flushes after endl

### DIFF
--- a/test/float.cpp
+++ b/test/float.cpp
@@ -30,7 +30,7 @@ void test_float(double precision, int runs = 1000) {
 		Float res = Op2()(a,b);
 
 		if (not accurate(res.reveal<double>(PUBLIC), Op()(da,db), precision)) {
-			cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl<<flush;
+			cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl;
 		}
 		assert(accurate(res.reveal<double>(PUBLIC),  Op()(da,db), precision*10));
 	}

--- a/test/float32.cpp
+++ b/test/float32.cpp
@@ -57,11 +57,11 @@ void test_float(double precision, int runs = 1000) {
 		
 		if(precision > 0.0) {
 			if (not accurate(res.reveal<double>(PUBLIC), Op()(da,db), precision)) {
-				cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl<<flush;
+				cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl;
 			}
 		} else {
 			if (not equal(res, Op()(da,db))) {
-				cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl<<flush;
+				cout << "Inaccuracy:\t"<<typeid(Op2).name()<<"\t"<< da <<"\t"<<db<<"\t"<<Op()(da,db)<<"\t"<<res.reveal<double>(PUBLIC)<<endl;
 			}
 		}
 	}

--- a/test/int.cpp
+++ b/test/int.cpp
@@ -26,7 +26,7 @@ void test_int(int party, int range1 = 1<<25, int range2 = 1<<25, int runs = 1000
 		Integer res = Op2()(a,b);
 
 		if (res.reveal<int>(PUBLIC) != Op()(ia,ib)) {
-			cout << ia <<"\t"<<ib<<"\t"<<Op()(ia,ib)<<"\t"<<res.reveal<int>(PUBLIC)<<endl<<flush;
+			cout << ia <<"\t"<<ib<<"\t"<<Op()(ia,ib)<<"\t"<<res.reveal<int>(PUBLIC)<<endl;
 		}
 		assert(res.reveal<int>(PUBLIC) == Op()(ia,ib));
 	}


### PR DESCRIPTION
`std::endl` [already flushes](https://en.cppreference.com/w/cpp/io/manip/endl).