### PR TITLE
Fix small memory leak and flush instead of fflush

### DIFF
--- a/emp-tool/io/net_io_channel.h
+++ b/emp-tool/io/net_io_channel.h
@@ -100,8 +100,8 @@ class NetIO: public IOChannel<NetIO> { public:
 	}
 
 	~NetIO(){
-		fflush(stream);
-		close(consocket);
+		flush();
+		fclose(stream);
 		delete[] buffer;
 	}
 


### PR DESCRIPTION
Valgrind found a `FILE*` which wasn't freed: `fdopen` should be paired with `fclose`. `flush()` instead of `fflush(stream)` aligns the code stylistically with the alternative version of the class.