### PR TITLE
Use CheckCSourceRuns instead of writing a file

### DIFF
--- a/cmake/source_of_randomness.cmake
+++ b/cmake/source_of_randomness.cmake
@@ -8,9 +8,10 @@ unset(RDSEED_RUN_RESULT CACHE)
 set(CMAKE_REQUIRED_FLAGS "-mrdseed") # in case CMAKE_C_FLAGS doesn't have it, ex. if add_compile_options is used instead
 check_c_source_runs("#include <x86intrin.h>\nint main(){\nunsigned long long r;\n_rdseed64_step(&r);\nreturn 0;\n}\n" RDSEED_RUN_RESULT)
 
-IF(NOT ${RDSEED_RUN_RESULT})
+string(COMPARE EQUAL "${RDSEED_RUN_RESULT}" "1" RDSEED_RUN_SUCCESS)
+IF(NOT ${RDSEED_RUN_SUCCESS})
 	set(USE_RANDOM_DEVICE ON)
-ENDIF(NOT ${RDSEED_RUN_RESULT})
+ENDIF(NOT ${RDSEED_RUN_SUCCESS})
 
 IF(${USE_RANDOM_DEVICE})
 	ADD_DEFINITIONS(-DEMP_USE_RANDOM_DEVICE)

--- a/cmake/source_of_randomness.cmake
+++ b/cmake/source_of_randomness.cmake
@@ -1,20 +1,16 @@
 OPTION(USE_RANDOM_DEVICE "Option description" OFF)
 
+include(CheckCSourceRuns)
+
 # Use rdseed if available
 unset(RDSEED_COMPILE_RESULT CACHE)
 unset(RDSEED_RUN_RESULT CACHE)
-file(WRITE ${CMAKE_SOURCE_DIR}/rdseedtest.c "#include <stdio.h>\n#include <x86intrin.h>\nint main(){\nunsigned long long r;\n_rdseed64_step(&r);\nreturn 0;\n}\n")
-try_run(RDSEED_RUN_RESULT RDSEED_COMPILE_RESULT ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR}/rdseedtest.c CMAKE_FLAGS ${CMAKE_C_FLAGS})
-file(REMOVE ${CMAKE_SOURCE_DIR}/rdseedtest.c)
+set(CMAKE_REQUIRED_FLAGS "-mrdseed") # in case CMAKE_C_FLAGS doesn't have it, ex. if add_compile_options is used instead
+check_c_source_runs("#include <x86intrin.h>\nint main(){\nunsigned long long r;\n_rdseed64_step(&r);\nreturn 0;\n}\n" RDSEED_RUN_RESULT)
 
-IF(NOT ${RDSEED_COMPILE_RESULT})
-        set(USE_RANDOM_DEVICE ON)
-ELSE(NOT ${RDSEED_COMPILE_RESULT})
-	string(COMPARE EQUAL "${RDSEED_RUN_RESULT}" "0" RDSEED_RUN_SUCCESS)
-        IF(NOT ${RDSEED_RUN_SUCCESS})
-                set(USE_RANDOM_DEVICE ON)
-        ENDIF(NOT ${RDSEED_RUN_SUCCESS})
-ENDIF(NOT ${RDSEED_COMPILE_RESULT})
+IF(NOT ${RDSEED_RUN_RESULT})
+	set(USE_RANDOM_DEVICE ON)
+ENDIF(NOT ${RDSEED_RUN_RESULT})
 
 IF(${USE_RANDOM_DEVICE})
 	ADD_DEFINITIONS(-DEMP_USE_RANDOM_DEVICE)
@@ -22,4 +18,3 @@ IF(${USE_RANDOM_DEVICE})
 ELSE(${USE_RANDOM_DEVICE})
 	message("${Green}-- Source of Randomness: rdseed${ColourReset}")
 ENDIF(${USE_RANDOM_DEVICE})
-


### PR DESCRIPTION
[2.8.11](https://cmake.org/cmake/help/v2.8.11/cmake.html#module:CheckCSourceRuns) even has it. I deleted the `stdio.h` include because it's not used.