### PR TITLE
Remove delete_array_null, as it's redundant

### DIFF
--- a/emp-tool/utils/utils.h
+++ b/emp-tool/utils/utils.h
@@ -15,9 +15,6 @@ using std::chrono::time_point;
 using std::chrono::high_resolution_clock;
 
 namespace emp {
-template<typename T>
-void inline delete_array_null(T * ptr);
-
 inline void error(const char * s, int line = 0, const char * file = nullptr);
 
 template<class... Ts>

--- a/emp-tool/utils/utils.hpp
+++ b/emp-tool/utils/utils.hpp
@@ -3,14 +3,6 @@ void run_function(void *function, const Ts&... args) {
 	reinterpret_cast<void(*)(Ts...)>(function)(args...);
 }
 
-template<typename T>
-void inline delete_array_null(T * ptr){
-	if(ptr != nullptr) {
-		delete[] ptr;
-		ptr = nullptr;
-	}
-}
-
 template <typename T>
 std::string m128i_to_string(const __m128i var) {
 	std::stringstream sstr;


### PR DESCRIPTION
It wasn't used anywhere other than emp-ot.