### PR TITLE
Fix CMakeLists.txt when use emp-tool as a submodule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,17 +3,20 @@ project (emptool)
 set(NAME "emp-tool")
 
 ADD_CUSTOM_COMMAND(
-  OUTPUT emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
+  OUTPUT ${CMAKE_SOURCE_DIR}/emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
   COMMAND xxd -i emp-tool/circuits/files/bristol_fashion/Keccak_f.txt emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.hex
-  COMMAND echo "#include \"emp-tool/circuits/sha3_256.h\"" > emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
+  COMMAND echo "\\#include \\\"emp-tool/circuits/sha3_256.h\\\"" > emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
   COMMAND cat emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.hex >> emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Compiling Keccak circuit file to binary")
 
 ADD_CUSTOM_COMMAND(
-  OUTPUT emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+  OUTPUT ${CMAKE_SOURCE_DIR}/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
   COMMAND xxd -i emp-tool/circuits/files/bristol_fashion/aes_128.txt emp-tool/circuits/files/bristol_fashion/aes_128.txt.hex
-  COMMAND echo "#include \"emp-tool/circuits/aes_128_ctr.h\"" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+  #COMMAND echo "\\#include \\\"emp-tool/circuits/aes_128_ctr.h\\\"" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+  COMMAND echo "" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
   COMMAND cat emp-tool/circuits/files/bristol_fashion/aes_128.txt.hex >> emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Compiling aes_128 circuit file to binary")
 
 set(sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,7 @@ ADD_CUSTOM_COMMAND(
 ADD_CUSTOM_COMMAND(
   OUTPUT ${CMAKE_SOURCE_DIR}/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
   COMMAND xxd -i emp-tool/circuits/files/bristol_fashion/aes_128.txt emp-tool/circuits/files/bristol_fashion/aes_128.txt.hex
-  #COMMAND echo "\\#include \\\"emp-tool/circuits/aes_128_ctr.h\\\"" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
-  COMMAND echo "" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
+  COMMAND echo "\\#include \\\"emp-tool/circuits/aes_128_ctr.h\\\"" > emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
   COMMAND cat emp-tool/circuits/files/bristol_fashion/aes_128.txt.hex >> emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   COMMENT "Compiling aes_128 circuit file to binary")

--- a/emp-tool/circuits/aes_128_ctr.h
+++ b/emp-tool/circuits/aes_128_ctr.h
@@ -5,6 +5,8 @@
 #include "emp-tool/execution/protocol_execution.h"
 #include "emp-tool/utils/block.h"
 #include "emp-tool/circuits/bit.h"
+#include "emp-tool/circuits/integer.h"
+#include "emp-tool/circuits/circuit_file.h"
 #include <stdio.h>
 #include <fstream>
 


### PR DESCRIPTION
Fixed when use emp-tool as a submodule by:

- set `OUTPUT` as absolutely path
- fix `echo` command
- add `WORKING_DIRECTORY` 