### PR TITLE
Added a cast that is necessary to compile aes_128_ctr.h if you use it as a library elsewhere

### DIFF
--- a/emp-tool/circuits/aes_128_ctr.h
+++ b/emp-tool/circuits/aes_128_ctr.h
@@ -50,7 +50,7 @@ int aes_128_ctr(const __m128i key,
 		output = (uint8_t *) input;
 	}
 	if (input == nullptr) { // then we're just doing a blind
-		input = output;
+		input = (T*) output;
 		for (size_t i = 0; i < num_bytes; ++i) {
 			output[i] = 0;
 		}


### PR DESCRIPTION
Not sure why it was working before, honestly, but there's this one cast on line 53 that's necessary.