### PR TITLE
Fix silent failure in CPU seed generation

### DIFF
--- a/emp-tool/io/highspeed_net_io_channel.h
+++ b/emp-tool/io/highspeed_net_io_channel.h
@@ -130,14 +130,21 @@ class HighSpeedNetIO : public IOChannel<HighSpeedNetIO> { public:
 	RecverSubChannel *rchannel;
 
 	HighSpeedNetIO(const char *address, int send_port, int recv_port, bool quiet = true) : quiet(quiet) {
+		if (send_port <0 || send_port > 65535)} {
+			throw std::runtime_error("Invalid send port number!");
+		}
+		if (recv_port <0 || recv_port > 65535)} {
+			throw std::runtime_error("Invalid receive port number!");
+		}
+
 		is_server = (address == nullptr);
 		if (is_server) {
 			recv_sock = server_listen(send_port);
 			usleep(2000);
-			send_sock = server_listen(recv_port & 0xFFFF);
+			send_sock = server_listen(recv_port);
 		} else {
 			send_sock = client_connect(address, send_port);
-			recv_sock = client_connect(address, recv_port & 0xFFFF);
+			recv_sock = client_connect(address, recv_port);
 		}
 		FSM = 0;
 		set_delay_opt(send_sock, true);

--- a/emp-tool/io/net_io_channel.h
+++ b/emp-tool/io/net_io_channel.h
@@ -29,7 +29,11 @@ class NetIO: public IOChannel<NetIO> { public:
 	string addr;
 	int port;
 	NetIO(const char * address, int port, bool quiet = false) {
-		this->port = port & 0xFFFF;
+		if (port <0 || port > 65535)} {
+			throw std::runtime_error("Invalid port number!");
+		}
+
+		this->port = port;
 		is_server = (address == nullptr);
 		if (address == nullptr) {
 			struct sockaddr_in dest;
@@ -38,7 +42,7 @@ class NetIO: public IOChannel<NetIO> { public:
 			memset(&serv, 0, sizeof(serv));
 			serv.sin_family = AF_INET;
 			serv.sin_addr.s_addr = htonl(INADDR_ANY); /* set our address to any interface */
-			serv.sin_port = htons(port);           /* set the server port number */    
+			serv.sin_port = htons(port);           /* set the server port number */
 			mysocket = socket(AF_INET, SOCK_STREAM, 0);
 			int reuse = 1;
 			setsockopt(mysocket, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuse, sizeof(reuse));
@@ -55,7 +59,7 @@ class NetIO: public IOChannel<NetIO> { public:
 		}
 		else {
 			addr = string(address);
-			
+
 			struct sockaddr_in dest;
 			memset(&dest, 0, sizeof(dest));
 			dest.sin_family = AF_INET;
@@ -68,7 +72,7 @@ class NetIO: public IOChannel<NetIO> { public:
 				if (connect(consocket, (struct sockaddr *)&dest, sizeof(struct sockaddr)) == 0) {
 					break;
 				}
-				
+
 				close(consocket);
 				usleep(1000);
 			}
@@ -135,7 +139,7 @@ class NetIO: public IOChannel<NetIO> { public:
 			int res = fread(sent + (char*)data, 1, len - sent, stream);
 			if (res >= 0)
 				sent += res;
-			else 
+			else
 				fprintf(stderr,"error: net_send_data %d\n", res);
 		}
 	}

--- a/emp-tool/utils/prg.h
+++ b/emp-tool/utils/prg.h
@@ -4,6 +4,7 @@
 #include "emp-tool/utils/aes.h"
 #include "emp-tool/utils/utils.h"
 #include "emp-tool/utils/constants.h"
+#include <climits>
 #include <memory>
 
 #ifdef ENABLE_RDSEED
@@ -32,11 +33,11 @@ class PRG { public:
 			unsigned long long r0, r1;
 			int i = 0;
 			for(; i < 10; ++i)
-				if(_rdseed64_step(&r0) == 1) break;
+				if((_rdseed64_step(&r0) == 1) && (r0 != ULLONG_MAX) && (r0 != 0)) break;
 			if(i == 10)error("RDSEED FAILURE");
 
 			for(i = 0; i < 10; ++i)
-				if(_rdseed64_step(&r1) == 1) break;
+				if((_rdseed64_step(&r1) == 1) && (r1 != ULLONG_MAX) && (r1 != 0)) break;
 			if(i == 10)error("RDSEED FAILURE");
 
 			v = makeBlock(r0, r1);


### PR DESCRIPTION
According to https://bugzilla.kernel.org/show_bug.cgi?id=85911, an AMD CPU may keep generating all zero or all one "random values" after sleep-resume.
This commit is to address this concern