### PR TITLE
Fix silent failure in CPU seed generation

### DIFF
--- a/emp-tool/utils/prg.h
+++ b/emp-tool/utils/prg.h
@@ -32,6 +32,7 @@ class PRG { public:
 #else
 			unsigned long long r0, r1;
 			int i = 0;
+			// To prevent an AMD CPU bug. (PR #156)
 			for(; i < 10; ++i)
 				if((_rdseed64_step(&r0) == 1) && (r0 != ULLONG_MAX) && (r0 != 0)) break;
 			if(i == 10)error("RDSEED FAILURE");

--- a/emp-tool/utils/prg.h
+++ b/emp-tool/utils/prg.h
@@ -4,6 +4,7 @@
 #include "emp-tool/utils/aes.h"
 #include "emp-tool/utils/utils.h"
 #include "emp-tool/utils/constants.h"
+#include <climits>
 #include <memory>
 
 #ifdef ENABLE_RDSEED
@@ -32,11 +33,11 @@ class PRG { public:
 			unsigned long long r0, r1;
 			int i = 0;
 			for(; i < 10; ++i)
-				if(_rdseed64_step(&r0) == 1) break;
+				if((_rdseed64_step(&r0) == 1) && (r0 != ULLONG_MAX) && (r0 != 0)) break;
 			if(i == 10)error("RDSEED FAILURE");
 
 			for(i = 0; i < 10; ++i)
-				if(_rdseed64_step(&r1) == 1) break;
+				if((_rdseed64_step(&r1) == 1) && (r1 != ULLONG_MAX) && (r1 != 0)) break;
 			if(i == 10)error("RDSEED FAILURE");
 
 			v = makeBlock(r0, r1);


### PR DESCRIPTION
According to https://bugzilla.kernel.org/show_bug.cgi?id=85911, an AMD CPU may keep generating all zero or all one "random values" after sleep-resume.
This commit is to address this concern