### PR TITLE
Fix build with -DCRYPTO_IN_CIRCUIT=true

### DIFF
--- a/emp-tool/circuits/aes_128_ctr.h
+++ b/emp-tool/circuits/aes_128_ctr.h
@@ -9,6 +9,7 @@
 #include "emp-tool/circuits/circuit_file.h"
 #include <stdio.h>
 #include <fstream>
+#include <memory>
 
 #include <openssl/evp.h>
 #include <stdlib.h>

--- a/emp-tool/circuits/sha3_256.h
+++ b/emp-tool/circuits/sha3_256.h
@@ -9,6 +9,7 @@
 #include "emp-tool/circuits/circuit_file.h"
 #include <stdio.h>
 #include <fstream>
+#include <memory>
 
 #include <openssl/evp.h>
 #include <stdlib.h>


### PR DESCRIPTION
Build fails with `-DCRYPTO_IN_CIRCUIT=true` on Arch Linux (GCC 12.1.0):

```
[ 26%] Building CXX object CMakeFiles/emp-tool.dir/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp.o
[ 29%] Building CXX object CMakeFiles/emp-tool.dir/emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp.o
In file included from /home/dragon/code/crypto/emp-tool2/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp:1:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:103:14: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
  103 |         std::unique_ptr<BristolFashion> circuit; // ensures circuit is deleted when this is deleted.
      |              ^~~~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:17:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   16 | #include <unistd.h>
  +++ |+#include <memory>
   17 | #include <errno.h>
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h: In constructor ‘emp::AES_128_CTR_Calculator::AES_128_CTR_Calculator()’:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:110:23: error: ‘class emp::AES_128_CTR_Calculator’ has no member named ‘circuit’
  110 |                 this->circuit = std::unique_ptr<BristolFashion>(new BristolFashion(circuit_file));
      |                       ^~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:110:38: error: ‘unique_ptr’ is not a member of ‘std’
  110 |                 this->circuit = std::unique_ptr<BristolFashion>(new BristolFashion(circuit_file));
      |                                      ^~~~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:110:38: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:110:63: error: expected primary-expression before ‘>’ token
  110 |                 this->circuit = std::unique_ptr<BristolFashion>(new BristolFashion(circuit_file));
      |                                                               ^
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h: In member function ‘int emp::AES_128_CTR_Calculator::aes_128_ctr(const emp::block*, const emp::block*, emp::block*, emp::block*, size_t, int, uint64_t)’:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:157:39: error: ‘class emp::AES_128_CTR_Calculator’ has no member named ‘circuit’
  157 |                                 this->circuit->compute(this->blind, this->keyiv);
      |                                       ^~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/aes_128_ctr.h:162:39: error: ‘class emp::AES_128_CTR_Calculator’ has no member named ‘circuit’
  162 |                                 this->circuit->compute(this->blind, this->keyiv);
      |                                       ^~~~~~~
make[2]: *** [CMakeFiles/emp-tool.dir/build.make:312: CMakeFiles/emp-tool.dir/emp-tool/circuits/files/bristol_fashion/aes_128.txt.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/dragon/code/crypto/emp-tool2/emp-tool/circuits/files/bristol_fashion/Keccak_f.txt.cpp:1:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:71:22: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   71 |                 std::unique_ptr<BristolFashion> keccak_f; // ensures keccak_f is deleted when this is deleted.
      |                      ^~~~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:17:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   16 | #include <unistd.h>
  +++ |+#include <memory>
   17 | #include <errno.h>
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h: In constructor ‘emp::SHA3_256_Calculator::SHA3_256_Calculator()’:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:80:25: error: ‘keccak_f’ was not declared in this scope; did you mean ‘keccak_f_txt’?
   80 |                         keccak_f = std::unique_ptr<BristolFashion>(new BristolFashion(keccak_f_txt));
      |                         ^~~~~~~~
      |                         keccak_f_txt
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:80:41: error: ‘unique_ptr’ is not a member of ‘std’
   80 |                         keccak_f = std::unique_ptr<BristolFashion>(new BristolFashion(keccak_f_txt));
      |                                         ^~~~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:80:41: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:80:66: error: expected primary-expression before ‘>’ token
   80 |                         keccak_f = std::unique_ptr<BristolFashion>(new BristolFashion(keccak_f_txt));
      |                                                                  ^
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h: In member function ‘void emp::SHA3_256_Calculator::sha3_256(emp::block*, const emp::block**, const size_t*, size_t)’:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:106:49: error: ‘keccak_f’ was not declared in this scope
  106 |                                                 keccak_f->compute(blocks, blocks);
      |                                                 ^~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:122:25: error: ‘keccak_f’ was not declared in this scope
  122 |                         keccak_f->compute(blocks, blocks);
      |                         ^~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h: In member function ‘void emp::SHA3_256_Calculator::sha3_256(emp::block*, const emp::Integer*, size_t)’:
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:145:49: error: ‘keccak_f’ was not declared in this scope
  145 |                                                 keccak_f->compute(blocks, blocks);
      |                                                 ^~~~~~~~
/home/dragon/code/crypto/emp-tool2/emp-tool/circuits/sha3_256.h:161:25: error: ‘keccak_f’ was not declared in this scope
  161 |                         keccak_f->compute(blocks, blocks);
      |                         ^~~~~~~~
```

Adding the suggested header fixes the issue.