### PR TITLE
Fix cast to maintain constness.

### DIFF
--- a/emp-tool/io/io_channel.h
+++ b/emp-tool/io/io_channel.h
@@ -78,7 +78,7 @@ class IOChannel { public:
 
 
 	void send_bool_aligned(const bool * data, size_t length) {
-		unsigned long long * data64 = (unsigned long long * )data;
+		const unsigned long long * data64 = (const unsigned long long * )data;
 		size_t i = 0;
 		for(; i < length/8; ++i) {
 			unsigned long long mask = 0x0101010101010101ULL;


### PR DESCRIPTION
Compiling ```emp-tool``` with high warnings on gives this error:

```
emp-tool/emp-tool/io/io_channel.h:81:56: error: cast from 'const bool *' to 'unsigned long long *' drops const qualifier [-Werror,-Wcast-qual]
                unsigned long long * data64 = (unsigned long long * )data;
```

It turns out that this can be made ```const``` without affecting the code. This is all this PR does. 

It's also clearer to the user -- otherwise, it looks like a ```const``` parameter (```data```) is being used in a mutable way.
