### PR TITLE
Return if input  == nullptr and output == nullptr

### DIFF
--- a/emp-tool/circuits/aes_128_ctr.h
+++ b/emp-tool/circuits/aes_128_ctr.h
@@ -46,7 +46,8 @@ int aes_128_ctr(const __m128i key,
 	}
 	if (input == nullptr && output == nullptr) {
 		std::cerr << "input and output of aes_128_ctr can't both be null pointers\n"<<std::flush;
-	}
+                return -1;
+        }
 	if (output == nullptr) { // then we're encrypting in place
 		output = (uint8_t *) input;
 	}


### PR DESCRIPTION
At the moment ```aes_128_ctr.h``` has this guard against ```input == nullptr && output == nullptr```:

https://github.com/emp-toolkit/emp-tool/blob/daa4454d5bca4861fa93166cef127a6071dc3874/emp-tool/circuits/aes_128_ctr.h#L47-L49

Unfortunately this doesn't stop the user from dereferencing a null pointer in the very next ``if`` statement:
https://github.com/emp-toolkit/emp-tool/blob/daa4454d5bca4861fa93166cef127a6071dc3874/emp-tool/circuits/aes_128_ctr.h#L50-L52

This PR simply adds a ```return -1``` if both ```input == nullptr``` and ```output == nullptr```: this prevents segmentation faults, but it preserves the error message. This should make it easy to diagnose the problem for the user, but also not cause any null dereferences.

If you want to test this, here's a failing test case:

```
#include <emp-tool/circuits/aes_128_ctr.h>
int main() {
   __m128i key{};
   __m128i iv{};
   uint8_t * input = nullptr;
   return emp::aes_128_ctr(key, iv, input, nullptr);
}
```

```
j> ./test
input and output of aes_128_ctr can't both be null pointers
Segmentation fault
```
