### PR TITLE
Fix bug in Hash::put_block

### DIFF
--- a/emp-tool/utils/hash.h
+++ b/emp-tool/utils/hash.h
@@ -34,8 +34,8 @@ class Hash { public:
 			size = nbyte;
 		}
 	}
-	void put_block(const block* block, int nblock=1){
-		put(block, sizeof(block)*nblock);
+	void put_block(const block* blk, int nblock=1){
+		put(blk, sizeof(block)*nblock);
 	}
 	void digest(void * a) {
 		if(size > 0) {


### PR DESCRIPTION
In the local scope of put_block, sizeof(block) returned 8 instead of 16 since block was a variable of pointer type. This caused only the first half of the data to be added to the hash when using put_block. Solved by renaming the argument to something other than "block".

I found the bug because previously
```c++
int main() {
	block digest_output[2];

	Hash hash1;
	hash1.put_block(&zero_block, 1);
	hash1.put_block(&all_one_block, 1);
	hash1.digest(digest_output);
	cout << digest_output[0] << '\n';

	Hash hash2;
	block blocks[2] = {zero_block, all_one_block};
	hash2.put_block(blocks, 2);
	hash2.digest(digest_output);
	cout << digest_output[0] << '\n';
}
```
printed two different hashes. With the fix this prints the same two hashes as expected.
