### PR TITLE
Fix segfault in sse_trans when nrows = 8

### DIFF
--- a/emp-tool/utils/block.h
+++ b/emp-tool/utils/block.h
@@ -121,7 +121,7 @@ inline void sse_trans(uint8_t *out, uint8_t const *inp, uint64_t nrows,
   assert(nrows % 8 == 0 && ncols % 8 == 0);
 
   // Do the main body in 16x8 blocks:
-  for (rr = 0; rr <= nrows - 16; rr += 16) {
+  for (rr = 0; rr + 16 <= nrows; rr += 16) {
     for (cc = 0; cc < ncols; cc += 8) {
       vec = _mm_set_epi8(INP(rr + 15, cc), INP(rr + 14, cc), INP(rr + 13, cc),
                          INP(rr + 12, cc), INP(rr + 11, cc), INP(rr + 10, cc),
@@ -142,7 +142,7 @@ inline void sse_trans(uint8_t *out, uint8_t const *inp, uint64_t nrows,
       (nrows % 8 == 0 && nrows % 16 != 0)) {
     // The fancy optimizations in the else-branch don't work if the above if-condition
     // holds, so we use the simpler non-simd variant for that case.
-    for (cc = 0; cc <= ncols - 16; cc += 16) {
+    for (cc = 0; cc + 16 <= ncols; cc += 16) {
       for (i = 0; i < 8; ++i) {
         tmp.b[i] = h = *(uint16_t const *)&INP(rr + i, cc);
         tmp.b[i + 8] = h >> 8;
@@ -153,7 +153,7 @@ inline void sse_trans(uint8_t *out, uint8_t const *inp, uint64_t nrows,
       }
     }
   } else {
-    for (cc = 0; cc <= ncols - 16; cc += 16) {
+    for (cc = 0; cc + 16 <= ncols; cc += 16) {
       vec = _mm_set_epi16(*(uint16_t const *)&INP(rr + 7, cc),
                           *(uint16_t const *)&INP(rr + 6, cc),
                           *(uint16_t const *)&INP(rr + 5, cc),


### PR DESCRIPTION
To reproduce the segfault: 
```
int main(int argc, char *argv[])
{
    uint8_t *foo = new uint8_t[256];
    uint8_t *bar = new uint8_t[256];
    sse_trans(foo, bar, 8, 256);
```

The reason is that since nrows is unsigned, nrows - 16 is a huge number when nrows  = 8.