### PR TITLE
Add support for feeding public labels.

### DIFF
--- a/emp-tool/execution/plain_prot.h
+++ b/emp-tool/execution/plain_prot.h
@@ -30,7 +30,13 @@ public:
 	}
 
 	void feed(block * label, int party, const bool* b, int length) override {
-		for(int i = 0; i < length; ++i)
+                if (party == PUBLIC) {
+                  for(int i = 0; i < length; ++i)
+                    label[i] = cast_circ_exec->public_label(b[i]);
+                  return;
+                }
+                
+                for(int i = 0; i < length; ++i)
 			label[i] = cast_circ_exec->private_label(b[i]);
 
 		if (party == ALICE) n1+=length;


### PR DESCRIPTION
At the moment, emp-tool treats public values as private, and adds the input wires to Bob's input: 

https://github.com/emp-toolkit/emp-tool/blob/5fbd7f7958237b553ba4b094766b182d5dfddeb3/emp-tool/execution/plain_prot.h#L32-L38

This PR marks the public values as public when being fed in. 

I'm not sure if this is all that's needed to make this work: if there's anything else @wangxiao1254, do let me know. 