### PR TITLE
fix relative paths in tests when emp included

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,12 +6,12 @@ endmacro()
 
 macro (add_test_case _name)
 	add_test_executable_with_lib(${_name} "emp-tool")
-  	add_test(NAME ${_name} COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_${_name}" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/")
+  	add_test(NAME ${_name} COMMAND "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_${_name}" WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/")
 endmacro()
 
 macro (add_test_case_with_run _name)
 	add_test_executable_with_lib(${_name} "emp-tool")
-	add_test(NAME ${_name} COMMAND "./run" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_${_name}" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/")
+	add_test(NAME ${_name} COMMAND "${PROJECT_SOURCE_DIR}/run" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test_${_name}" WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/")
 
 endmacro()
 


### PR DESCRIPTION
When including emp from a parent cmake project, the tests fail because ./run is not found in the path.

Also needed to set working directory at the project level (not the global cmake level) so circuit files are correctly found.