### PR TITLE
Use default setting for RPATH on macOS

### DIFF
--- a/cmake/emp-base.cmake
+++ b/cmake/emp-base.cmake
@@ -18,7 +18,6 @@ if(NOT WIN32)
   set(BoldWhite   "${Esc}[1;37m")
 endif()
 
-set(CMAKE_MACOSX_RPATH 0)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 include_directories(${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Current code forces RPATH=0 on macOS.
This makes it much harder to use the library in non-standard install location (in particular when wanting to not install with sudo).

This commit reverts back to the default setting, which is using rpath by default.