### PR TITLE
[Bug fix] should call hash function with circular correlation robustness

### DIFF
--- a/emp-tool/gc/halfgate_eva.h
+++ b/emp-tool/gc/halfgate_eva.h
@@ -16,7 +16,7 @@ inline block halfgates_eval(block A, block B, const block *table, MITCCRH<8> *mi
 	block H[2];
 	H[0] = A;
 	H[1] = B;
-	mitccrh->hash<2,1>(H);
+	mitccrh->hash_cir<2,1>(H);
 	HA = H[0];
 	HB = H[1];
 

--- a/emp-tool/gc/halfgate_gen.h
+++ b/emp-tool/gc/halfgate_gen.h
@@ -22,7 +22,7 @@ inline block halfgates_garble(block LA0, block A1, block LB0, block B1, block de
 	H[1] = A1;
 	H[2] = LB0;
 	H[3] = B1;
-	mitccrh->hash<2,2>(H);
+	mitccrh->hash_cir<2,2>(H);
 	HLA0 = H[0];
 	HA1 = H[1];
 	HLB0 = H[2];


### PR DESCRIPTION
For half gates garbling and evaluating, we should instantiate the H function with `hash_cir` instead of `hash` in `MITCCRH`, in order to satisfy circular correlation robustness pointed out by:

[Better Concrete Security for Half-Gates Garbling (in the Multi-Instance Setting)](https://eprint.iacr.org/2019/1168.pdf)