### PR TITLE
[upgrade] ThreadPool now supports C++20

### DIFF
--- a/emp-tool/utils/ThreadPool.h
+++ b/emp-tool/utils/ThreadPool.h
@@ -39,8 +39,13 @@ class ThreadPool {
 public:
     ThreadPool(size_t);
     template<class F, class... Args>
+#if __cplusplus >= 202002L
+    auto enqueue(F&& f, Args&&... args) 
+        -> std::future<typename std::invoke_result<F,Args...>::type>;
+#else
     auto enqueue(F&& f, Args&&... args) 
         -> std::future<typename std::result_of<F(Args...)>::type>;
+#endif	
     ~ThreadPool();
 	int size() const;
 private:
@@ -87,11 +92,19 @@ inline ThreadPool::ThreadPool(size_t threads)
 }
 
 // add new work item to the pool
+#if __cplusplus >= 202002L
+template<class F, class... Args>
+auto ThreadPool::enqueue(F&& f, Args&&... args) 
+    -> std::future<typename std::invoke_result<F,Args...>::type>
+{
+    using return_type = typename std::invoke_result<F,Args...>::type;
+#else
 template<class F, class... Args>
 auto ThreadPool::enqueue(F&& f, Args&&... args) 
     -> std::future<typename std::result_of<F(Args...)>::type>
 {
     using return_type = typename std::result_of<F(Args...)>::type;
+#endif
 
     auto task = std::make_shared< std::packaged_task<return_type()> >(
             std::bind(std::forward<F>(f), std::forward<Args>(args)...)


### PR DESCRIPTION
Upgrade ThreadPool.h file to support C++20. In particular, `std::result_of` will be replaced by `std::invoke_result` accordingly.