### PR TITLE
fix PRG alignment bug

### DIFF
--- a/test/prg.cpp
+++ b/test/prg.cpp
@@ -52,7 +52,7 @@ int main() {
 }
 
 void test_unaligned() {
-    block seed(123, 456);
+    block seed = makeBlock(123, 456);
 
     block ref_data[4];
     uint8_t* ref_bytes = (uint8_t*)ref_data;

--- a/test/prg.cpp
+++ b/test/prg.cpp
@@ -9,6 +9,9 @@ using namespace emp;
 #include <map>
 #include <random>
 #include <cmath>
+
+void test_unaligned();
+
 int main() {
 	PRG gen;
 	std::normal_distribution<> d{5,2};
@@ -22,8 +25,6 @@ int main() {
 			<< p.first << ' ' << std::string(p.second/200, '*') << '\n';
 	}
 
-
-
 	PRG prg;//using a random seed
 
 	block rand_block[3];
@@ -31,10 +32,7 @@ int main() {
 
 	prg.reseed(&rand_block[1]);//reset the PRG with another seed
 
-	int rand_ints[100];
-	int a = 0;
-	prg.random_data_unaligned(rand_ints+1, sizeof(int)*99);//when the array is not 128-bit-aligned
-	cout << a<<"\n";
+    test_unaligned();
 
 	prg.reseed(&zero_block);
 	for (long long length = 2; length <= 8192; length*=2) {
@@ -51,4 +49,33 @@ int main() {
 		cout << "PRG speed with block size "<<length<<" :\t"<<(length*times*128)/(interval+0.0)*1e6*1e-9<<" Gbps\n";
 	}
 	return 0;
+}
+
+void test_unaligned() {
+    block seed(123, 456);
+
+    block ref_data[4];
+    uint8_t* ref_bytes = (uint8_t*)ref_data;
+    {
+        PRG prg(&seed);
+        prg.random_data_unaligned(ref_data, 4 * sizeof(block));
+    }
+
+    uint8_t buf[64];
+
+    for (int offset = 1; offset < 16; offset++) {
+        for (int len = 1; len < 64 - offset; len++) {
+            uint8_t* unaligned_buf = buf + offset;
+            PRG prg(&seed);
+            prg.random_data_unaligned(unaligned_buf, len);
+
+            for (int i = 0; i < len; i++) {
+                if (unaligned_buf[i] != ref_bytes[i]) {
+                    cout << "ERROR: Mismatch at offset " << offset << ", ";
+                    cout << "len " << len << ", i " << i << endl;
+                    return;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
In the original code, if `data` does not align to a block boundary, we push the ptr forward to the next boundary with `std::align`, fill the random bytes there instead, and afterwards fill in the front unaligned bytes that were skipped.

The problem with this is that the resulting byte sequence is alignment dependent. This creates a bug in `emp-agmpc` because it relies on all participants generating a consistent bool sequence here:
```cpp
block prg_key = sampleRandom(io, &prg, pool, party); // <----- All participants get the same key (seed)
PRG prgf(&prg_key);
char (*dgst)[Hash::DIGEST_SIZE] = new char[nP+1][Hash::DIGEST_SIZE];
bool * tmp = new bool[length*bucket_size]; // <--------------- Unknown alignment!
for(int i = 0; i < ssp; ++i) {
	prgf.random_bool(tmp, length*bucket_size); // <------- Supposed to generate the same bools here
	X[party][i] = inProd(tmp, tKEYphi[party], length*bucket_size);
}
```
https://github.com/emp-toolkit/emp-agmpc/blob/0add81e/emp-agmpc/fpremp.h#L194-L201

This leads to the `"AND check"` failing a bit further down.

Since this bug is about alignment, it might be difficult to replicate in other environments, but it happened on my webassembly port here: https://github.com/voltrevo/emp-wasm/tree/738395dc65bda76f199507a96928d2f477875029. (`npm install`, `npm run build`, `npm test`.)

This PR fixes the issue and adds a test. I checked the test fails pre-fix and passes post-fix.