### PR TITLE
Added ENABLE_COMM_STATS logic to track communication rounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories(${OPENSSL_INCLUDE_DIR})
 
 
 add_library(${NAME} SHARED ${sources})
+#target_compile_definitions(${NAME} PRIVATE ENABLE_COMM_STATS)
 
 install(DIRECTORY emp-tool DESTINATION include/)
 install(DIRECTORY cmake/ DESTINATION cmake/)

--- a/emp-tool/io/io_channel.h
+++ b/emp-tool/io/io_channel.h
@@ -8,7 +8,7 @@
 
 namespace emp {
 template<typename T>
-class IOChannel { public:
+class IOChannel {
 #ifdef ENABLE_COMM_STATS
 	enum CommOpType { NONE, SEND, RECV };
 #endif // ENABLE_COMM_STATS

--- a/emp-tool/io/io_channel.h
+++ b/emp-tool/io/io_channel.h
@@ -4,18 +4,36 @@
 #include "emp-tool/utils/prg.h"
 #include "emp-tool/utils/group.h"
 #include <memory>
-#include <cassert>  
+#include <cassert>
 
 namespace emp {
-template<typename T> 
+template<typename T>
 class IOChannel { public:
+#ifdef ENABLE_COMM_STATS
+	enum CommOpType { NONE, SEND, RECV };
+#endif // ENABLE_COMM_STATS
+public:
 	uint64_t counter = 0;
+#ifdef ENABLE_COMM_STATS
+	uint64_t comm_rounds = 0;
+	CommOpType previous_op = NONE;
+#endif // ENABLE_COMM_STATS
 	void send_data(const void * data, size_t nbyte) {
 		counter +=nbyte;
+#ifdef ENABLE_COMM_STATS
+		if (previous_op == RECV)
+			comm_rounds++;
+		previous_op = SEND
+#endif // ENABLE_COMM_STATS
 		derived().send_data_internal(data, nbyte);
 	}
 
 	void recv_data(void * data, size_t nbyte) {
+#ifdef ENABLE_COMM_STATS
+		if (previous_op == SEND)
+			comm_rounds++;
+		previous_op = RECV
+#endif // ENABLE_COMM_STATS
 		derived().recv_data_internal(data, nbyte);
 	}
 
@@ -48,7 +66,7 @@ class IOChannel { public:
 			recv_data(tmp, len);
 			A[i].from_bin(g, tmp, len);
 		}
-	}	
+	}
 
 	void send_bool(bool * data, size_t length) {
 		void * ptr = (void *)data;
@@ -119,7 +137,7 @@ class IOChannel { public:
 #endif
                         memcpy(data64, &unpack, sizeof(unpack));
                         data64 += sizeof(unpack);
-                        
+
 		}
 		if (8*i != length)
 			recv_data(data + 8*i, length - 8*i);


### PR DESCRIPTION
Coded in reference to the comment from #200.

Simply added a logic to track previous operation (send/recv) and count the communication rounds happened, and wrapped it with a compilation macro guard around.